### PR TITLE
Support setting player parameter 'rel'

### DIFF
--- a/youtube.go
+++ b/youtube.go
@@ -175,7 +175,7 @@ type PlayerParams struct {
 	Origin         string          `js:"origin"`
 	Playlist       []string        `js:"playlist"`
 	PlaysInline    int             `js:"playsinline"`
-	Related        int             `js:"rel"`
+	Rel            int             `js:"rel"`
 	ShowInfo       int             `js:"showinfo"`
 	Start          int             `js:"start"`
 	WidgetReferrer string          `js:"widget_referrer"`

--- a/youtube.go
+++ b/youtube.go
@@ -175,6 +175,7 @@ type PlayerParams struct {
 	Origin         string          `js:"origin"`
 	Playlist       []string        `js:"playlist"`
 	PlaysInline    int             `js:"playsinline"`
+	Related        int             `js:"rel"`
 	ShowInfo       int             `js:"showinfo"`
 	Start          int             `js:"start"`
 	WidgetReferrer string          `js:"widget_referrer"`


### PR DESCRIPTION
Added the `rel` player parameter to be able to disable showing related videos when playback is stopped/ends. See https://developers.google.com/youtube/player_parameters.